### PR TITLE
Update to Docker 20.10.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ None.
 ```yaml
 ---
 docker_add_alias: true
-docker_release: "20.10.19"
-docker_release_shasum: "ddcd732baaa03958cc8f326a5dca09bcd8f348bb7d2737aaf67bbdd7d80302d1"
-docker_release_rootless_shasum: "abb2ce291372ea3850c3a66bd028318ffcbfcbdaab9a19d04cbf096c27057c2e"
+docker_release: "20.10.20"
+docker_release_shasum: "a303cee9125c89abbbb6c4f044b3e2c01c7895e373b90d8de16a7ed25bb2530a"
+docker_release_rootless_shasum: "cb95463a9c7a4ec810c72312af6a797d1ebe1d31c8e623208526fdcb8f57db41"
 docker_bash_completion_shasum: "cd9c70120bc5f7e6772b6a5350abf63099004c357814abc8a8a3689a7f2e3df0"
 docker_compose_bash_completion_shasum: "9926c945b466fad570ad574089d6a90f7d9ba452a2d6a8ba67611a664707f0de"
 docker_rootful: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
 # https://github.com/docker/roadmap/issues/188
-# https://download.docker.com/linux/static/stable/x86_64/{docker,docker-rootless-extras}-20.10.19.tgz
+# https://download.docker.com/linux/static/stable/x86_64/{docker,docker-rootless-extras}-20.10.20.tgz
 docker_add_alias: true
-docker_release: "20.10.19"
-docker_release_shasum: "ddcd732baaa03958cc8f326a5dca09bcd8f348bb7d2737aaf67bbdd7d80302d1"
-docker_release_rootless_shasum: "abb2ce291372ea3850c3a66bd028318ffcbfcbdaab9a19d04cbf096c27057c2e"
+docker_release: "20.10.20"
+docker_release_shasum: "a303cee9125c89abbbb6c4f044b3e2c01c7895e373b90d8de16a7ed25bb2530a"
+docker_release_rootless_shasum: "cb95463a9c7a4ec810c72312af6a797d1ebe1d31c8e623208526fdcb8f57db41"
 docker_bash_completion_shasum: "cd9c70120bc5f7e6772b6a5350abf63099004c357814abc8a8a3689a7f2e3df0"
 docker_compose_bash_completion_shasum: "9926c945b466fad570ad574089d6a90f7d9ba452a2d6a8ba67611a664707f0de"
 docker_rootful: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,4 +4,4 @@
   tasks:
     - name: "Include docker_rootless"
       ansible.builtin.include_role:
-        name: "ansible-docker-rootless"
+        name: "ansible-role-docker-rootless"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,8 +6,6 @@ driver:
   name: vagrant
   provider:
     name: virtualbox
-  provider_options:
-    linked_clone: false
 provisioner:
   name: ansible
   config_options:


### PR DESCRIPTION
This PR:
- bumps Docker to 20.10.20
- corrects the molecule converge task
- removes the linked_clone option