### PR TITLE
deprecate apt_key, use organise installation tasks using blocks

### DIFF
--- a/tasks/docker_install_rootful.yml
+++ b/tasks/docker_install_rootful.yml
@@ -4,52 +4,53 @@
   tags:
     - fact
 
-- name: Import Docker gpg key
-  become: true
-  ansible.builtin.apt_key:
-    url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
-    state: present
-  when: ansible_os_family == "Debian"
+- name: Install Docker for Debian family
   tags:
     - apt
     - docker
-
-- name: Add apt Docker repository
-  become: true
-  ansible.builtin.template:
-    src: docker.repo.j2
-    dest: /etc/apt/sources.list.d/docker.list
-    backup: true
-    mode: 0644
-    owner: root
-    group: root
   when: ansible_os_family == "Debian"
-  tags:
-    - apt
-    - docker
+  block:
+    - name: Import Docker gpg key
+      become: true
+      ansible.builtin.get_url:
+        url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+        dest: /etc/apt/trusted.gpg.d/docker.asc
+        mode: '0644'
+        force: true
 
-- name: Run apt update
-  become: true
-  ansible.builtin.apt:
-    update_cache: true
-  when: ansible_os_family == "Debian"
-  tags:
-    - apt
+    - name: Add apt Docker repository
+      become: true
+      ansible.builtin.template:
+        src: docker.repo.j2
+        dest: /etc/apt/sources.list.d/docker.list
+        backup: true
+        mode: 0644
+        owner: root
+        group: root
 
-- name: Stat docker-ce.repo file
-  ansible.builtin.stat:
-    path: "/etc/yum.repos.d/docker-ce.repo"
-  register: docker_ce_repo
+    - name: Run apt update
+      become: true
+      ansible.builtin.apt:
+        update_cache: true
 
-- name: Add Docker yum repo
-  become: true
-  ansible.builtin.command:
-    cmd: "dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo"
-  when: ansible_os_family == "RedHat" and not docker_ce_repo.stat.exists
+- name: Install Docker for RedHat family
+  when: ansible_os_family == "RedHat"
   tags:
     - dnf
+    - docker
+  block:
+    - name: Stat docker-ce.repo file
+      ansible.builtin.stat:
+        path: "/etc/yum.repos.d/docker-ce.repo"
+      register: docker_ce_repo
 
-- name: Install docker
+    - name: Add Docker yum repo
+      become: true
+      ansible.builtin.command:
+        cmd: "dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo"
+      when: not docker_ce_repo.stat.exists
+
+- name: Install Docker
   become: true
   ansible.builtin.package:
     name: ['docker-ce', 'docker-ce-rootless-extras']

--- a/templates/docker.repo.j2
+++ b/templates/docker.repo.j2
@@ -1,1 +1,1 @@
-deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} stable
+deb [signed_by=/etc/apt/trusted.gpg.d/docker.asc] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} stable


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>