### PR TITLE
Ensure sysctl user.max_user_namespaces is set in rootless mode

### DIFF
--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -156,6 +156,18 @@
   tags:
     - sysctl
 
+- name: Sysctl user.max_user_namespaces=28633
+  become: true
+  ansible.posix.sysctl:
+    name: user.max_user_namespaces
+    value: "28633"
+    sysctl_set: true
+    state: present
+    reload: true
+  when: not docker_rootful
+  tags:
+    - sysctl
+
 - name: Load the overlay module
   become: true
   community.general.modprobe:


### PR DESCRIPTION
In Ubuntu 22.04 it seems user.max_user_namespaces=0 by default, which makes dockerd fail with 

> error: failed to start the child: fork/exec /proc/self/exe: no space left on device

when starting as a non-root user. We should ensure that user.max_user_namespaces is being set by sysctl. PR will set user.max_user_namespaces=28633 as suggested by the Docker docs.

src: https://docs.docker.com/engine/security/rootless/#troubleshooting

