### PR TITLE
Disable docker.service and docker.socket

### DIFF
--- a/tasks/docker_service_rootful.yml
+++ b/tasks/docker_service_rootful.yml
@@ -11,18 +11,26 @@
 - name: Disable rootful Docker daemon
   become: true
   ansible.builtin.systemd:
-    name: docker
+    name: "{{ item }}"
     state: stopped
     enabled: false
+  loop:
+    - docker.service
+    - docker.socket
+    - containerd.service
   when:
     - not docker_rootful_enabled
 
 - name: Enable rootful Docker daemon
   become: true
   ansible.builtin.systemd:
-    name: docker
+    name: "{{ item }}"
     state: started
     enabled: true
+  loop:
+    - docker.service
+    - docker.socket
+    - containerd.service
   when:
     - docker_rootful_enabled
 


### PR DESCRIPTION
The role needs to stop/disable the `docker.socket` as well, otherwise the `docker.service` runs again after a system reboot.

Also added `containerd.service` since it's mentioned in the [docs](https://docs.docker.com/engine/install/linux-postinstall/#configure-docker-to-start-on-boot-with-systemd).