### PR TITLE
Fix path growth in docker_rootless.sh.j2

### DIFF
--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -8,6 +8,7 @@
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 1800
+      changed_when: false
 
     - name: Install Debian family packages
       ansible.builtin.apt:

--- a/templates/docker_rootless.sh.j2
+++ b/templates/docker_rootless.sh.j2
@@ -7,7 +7,7 @@
 # Ensure the following environment variables are set when managing
 # the docker service:
 #  XDG_RUNTIME_DIR="/run/user/{{ docker_user_info.uid }}"
-#  PATH="{{ docker_user_info.home }}/bin:{{ ansible_env.PATH }}"
+#  PATH="{{ docker_user_info.home }}/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 #  DOCKER_HOST="unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
 #
 # See https://docs.docker.com/engine/security/rootless/ for more information.


### PR DESCRIPTION
fixes two changes that come up on most runs:
- PATH comment grows on every execution in `docker_rootless.sh.j2`, e.g.:
```
#  PATH="/home/dockeruser/bin:/home/docker-runner/bin:/home/dockeruser/bin:/usr/local/bin:/usr/bin:/bin:/usr/games"
```
- ignore changes of task `Run apt update` 