### PR TITLE
bashrc: add custom blockinfile marker to avoid collision

### DIFF
--- a/tasks/bashrc.yml
+++ b/tasks/bashrc.yml
@@ -34,6 +34,7 @@
           export XDG_RUNTIME_DIR="/run/user/{{ docker_user_info.uid }}"
           export DOCKER_HOST="unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
           export PATH="{{ docker_user_info.home }}/bin:{{ docker_user_info.home }}/.local/bin:$PATH"
+        marker: "# {mark} ANSIBLE MANAGED BLOCK - docker"
 
     - name: Install Docker bash completion
       environment:


### PR DESCRIPTION
Adds a unique marker to the Docker-related `blockinfile` in `.bashrc` to prevent collisions with other Ansible-managed blocks. This keeps the Docker config isolated when multiple roles modify the same file.

Note: On systems where the role was applied previously without a marker, this may lead to duplicate blocks. These should be harmless though.
