### PR TITLE
fix(tasks): map aarch64 and x86_64 to Docker repo arch names

### DIFF
--- a/tasks/docker_install_rootful.yml
+++ b/tasks/docker_install_rootful.yml
@@ -26,7 +26,7 @@
         name: Docker
         types: deb
         uris: https://download.docker.com/linux/{{ ansible_facts.distribution | lower }}
-        architectures: "{{ 'amd64' if ansible_facts.architecture == 'x86_64' else ansible_facts.architecture }}"
+        architectures: "{{ {'x86_64': 'amd64', 'aarch64': 'arm64'}.get(ansible_facts.architecture, ansible_facts.architecture) }}"
         suites: "{{ ansible_facts.distribution_release }}"
         components:
           - stable


### PR DESCRIPTION
This fixes bug where apt package `docker-buildx-plugin` could not be found when using rootful docker.
After investigation, found that the architecture listed in `/etc/apt/sources.list.d/docker.sources` should
be `arm64` instead of `aarch64`.