### PR TITLE
migrate binaries to ~/.local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ docker_compose_url: https://github.com/docker/compose/releases/download
 docker_daemon_json_template: daemon.json.j2
 docker_driver_network: slirp4netns
 docker_driver_port: builtin
+docker_migrate_legacy_bin: true
 docker_release: 29.6.1
 docker_repository_template: docker.repo.j2
 docker_rootful_enabled: false
@@ -115,6 +116,18 @@ dependencies.
 The `docker_url`, `docker_release`, `docker_compose_url` and `docker_compose_release`
 variables define where you find the relevant binaries and which version you
 should use when doing a manual installation.
+
+The `docker` and `docker-compose` binaries, along with the rootless install
+scripts, are installed into `~/.local/bin` of the `docker_user`. The legacy
+`~/bin` directory is still kept in every `PATH` the role configures, after
+`~/.local/bin`, so any binaries or scripts you place there manually continue
+to take effect.
+
+If `docker_migrate_legacy_bin: true` (the default), any binaries the role
+previously installed into `~/bin` are moved into `~/.local/bin` the first
+time the updated role runs against a host, so the Docker binaries end up in
+a single location and `~/bin` is left free for your own use. Set it to
+`false` to leave the contents of `~/bin` untouched.
 
 You define the name of the Docker user that will be created with the
 `docker_user` variable. This user will download and install the binaries if
@@ -202,7 +215,7 @@ configuration.
 - name: Example container block
   environment:
     XDG_RUNTIME_DIR: "/run/user/{{ docker_user_info.uid }}"
-    PATH: "{{ docker_user_info.home }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:{{ ansible_env.PATH }}"
     DOCKER_HOST: "unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
   block:
     - name: Nginx container
@@ -239,7 +252,7 @@ configuration.
   become_user: "{{ docker_user }}"
   environment:
     XDG_RUNTIME_DIR: /run/user/{{ docker_user_info.uid }}
-    PATH: "{{ docker_user_info.home }}/bin:{{ ansible_env.PATH }}"
+    PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:{{ ansible_env.PATH }}"
     DOCKER_HOST: "unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
   block:
     - name: Install pip dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ docker_compose_url: https://github.com/docker/compose/releases/download
 docker_daemon_json_template: daemon.json.j2
 docker_driver_network: slirp4netns
 docker_driver_port: builtin
+docker_migrate_legacy_bin: true
 docker_release: 29.6.1
 docker_repository_template: docker.repo.j2
 docker_rootful_enabled: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -271,7 +271,7 @@
       become_user: "{{ docker_user }}"
       environment:
         XDG_RUNTIME_DIR: /run/user/{{ docker_user_info.uid }}
-        PATH: "{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
+        PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
         DOCKER_HOST: unix:///run/user/{{ docker_user_info.uid }}/docker.sock
       block:
         - name: Verify Docker compose
@@ -286,7 +286,7 @@
         - name: Run Docker Compose
           environment:
             XDG_RUNTIME_DIR: /run/user/{{ docker_user_info.uid }}
-            PATH: "{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
+            PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
             DOCKER_HOST: unix:///run/user/{{ docker_user_info.uid }}/docker.sock
           ansible.builtin.command:
             cmd: docker compose -f "/var/tmp/{{ docker_user }}-docker-compose.yml" up -d
@@ -308,7 +308,7 @@
       become_user: "{{ docker_user }}"
       environment:
         XDG_RUNTIME_DIR: /run/user/{{ docker_user_info.uid }}
-        PATH: "{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
+        PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
         DOCKER_HOST: unix:///run/user/{{ docker_user_info.uid }}/docker.sock
       block:
         - name: Install pip dependencies
@@ -340,7 +340,7 @@
         - docker_rootful
       environment:
         XDG_RUNTIME_DIR: /run/user/{{ docker_user_info.uid }}
-        PATH: "{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
+        PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
         DOCKER_HOST: unix:///run/user/{{ docker_user_info.uid }}/docker.sock
       block:
         - name: Write Dockerfile
@@ -367,7 +367,7 @@
     - name: Container usage verification block
       environment:
         XDG_RUNTIME_DIR: /run/user/{{ docker_user_info.uid }}
-        PATH: "{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
+        PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
         DOCKER_HOST: unix:///run/user/{{ docker_user_info.uid }}/docker.sock
       when:
         - ansible_facts.virtualization_type not in ["container", "docker", "podman"]

--- a/tasks/bashrc.yml
+++ b/tasks/bashrc.yml
@@ -33,12 +33,12 @@
         block: |
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"
           export DOCKER_HOST="unix://${XDG_RUNTIME_DIR}/docker.sock"
-          export PATH="${HOME}/bin:${HOME}/.local/bin:$PATH"
+          export PATH="${HOME}/.local/bin:${HOME}/bin:$PATH"
         marker: "# {mark} ANSIBLE MANAGED BLOCK - docker"
 
     - name: Install Docker bash completion
       environment:
-        PATH: "{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
+        PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
       ansible.builtin.shell: |
         set -o pipefail
         docker completion bash | tee "{{ docker_user_info.home }}/.bash_completion.d/docker"

--- a/tasks/docker_compose.yml
+++ b/tasks/docker_compose.yml
@@ -16,9 +16,33 @@
   become: true
   become_user: "{{ docker_user }}"
   block:
-    - name: Stat Compose in /bin dir
+    - name: Stat legacy Compose in ~/bin dir
       ansible.builtin.stat:
         path: "{{ docker_user_info.home }}/bin/docker-compose"
+      register: docker_compose_legacy_bin
+      when: docker_migrate_legacy_bin
+
+    - name: Migrate legacy Compose into ~/.local/bin
+      ansible.builtin.copy:
+        src: "{{ docker_user_info.home }}/bin/docker-compose"
+        dest: "{{ docker_user_info.home }}/.local/bin/docker-compose"
+        remote_src: true
+        mode: preserve
+      when:
+        - docker_migrate_legacy_bin
+        - docker_compose_legacy_bin.stat.exists | default(false)
+
+    - name: Remove migrated legacy Compose from ~/bin
+      ansible.builtin.file:
+        path: "{{ docker_user_info.home }}/bin/docker-compose"
+        state: absent
+      when:
+        - docker_migrate_legacy_bin
+        - docker_compose_legacy_bin.stat.exists | default(false)
+
+    - name: Stat Compose in .local/bin dir
+      ansible.builtin.stat:
+        path: "{{ docker_user_info.home }}/.local/bin/docker-compose"
       register: docker_compose_bin
 
     - name: Create cli-plugins directory
@@ -35,9 +59,9 @@
         owner: "{{ docker_user }}"
         mode: "0755"
 
-    - name: Remove Compose in /bin dir
+    - name: Remove Compose in .local/bin dir
       ansible.builtin.file:
-        path: "{{ docker_user_info.home }}/bin/docker-compose"
+        path: "{{ docker_user_info.home }}/.local/bin/docker-compose"
         state: absent
       when:
         - docker_compose_bin.stat.exists
@@ -46,5 +70,5 @@
     - name: Create Compose link
       ansible.builtin.file:
         src: "{{ docker_user_info.home }}/.docker/cli-plugins/docker-compose"
-        dest: "{{ docker_user_info.home }}/bin/docker-compose"
+        dest: "{{ docker_user_info.home }}/.local/bin/docker-compose"
         state: link

--- a/tasks/docker_install_rootless.yml
+++ b/tasks/docker_install_rootless.yml
@@ -1,20 +1,56 @@
 ---
+- name: Create Docker user .local/bin directory
+  become: true
+  become_user: "{{ docker_user }}"
+  ansible.builtin.file:
+    path: "{{ docker_user_info.home }}/.local/bin"
+    state: directory
+    mode: "0700"
+
+- name: Migrate legacy ~/bin binaries into ~/.local/bin
+  become: true
+  become_user: "{{ docker_user }}"
+  when: docker_migrate_legacy_bin
+  block:
+    - name: Stat legacy Docker user bin directory
+      ansible.builtin.stat:
+        path: "{{ docker_user_info.home }}/bin"
+      register: docker_legacy_bin_dir
+
+    - name: Find binaries in legacy Docker user bin directory
+      ansible.builtin.find:
+        paths: "{{ docker_user_info.home }}/bin"
+        file_type: any
+        hidden: true
+      register: docker_legacy_bin_files
+      when: docker_legacy_bin_dir.stat.isdir | default(false)
+
+    - name: Copy legacy binaries into ~/.local/bin
+      ansible.builtin.copy:
+        src: "{{ item.path }}"
+        dest: "{{ docker_user_info.home }}/.local/bin/{{ item.path | basename }}"
+        remote_src: true
+        mode: preserve
+      loop: "{{ docker_legacy_bin_files.files | default([]) }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+
+    - name: Remove migrated legacy binaries from ~/bin
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ docker_legacy_bin_files.files | default([]) }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+
 - name: Get Docker version
   become: true
   become_user: "{{ docker_user }}"
   ansible.builtin.command:
-    cmd: "{{ docker_user_info.home }}/bin/docker version"
+    cmd: "{{ docker_user_info.home }}/.local/bin/docker version"
   register: rootless_docker_version
   changed_when: false
   failed_when: false
-
-- name: Create Docker user bin directory
-  become: true
-  become_user: "{{ docker_user }}"
-  ansible.builtin.file:
-    path: "{{ docker_user_info.home }}/bin"
-    state: directory
-    mode: "0700"
 
 - name: Create user systemd .config directory
   become: true
@@ -55,24 +91,24 @@
         owner: "{{ docker_user }}"
         mode: "0644"
 
-    - name: Extract Docker archive into Docker user bin directory
+    - name: Extract Docker archive into Docker user .local/bin directory
       become: true
       become_user: "{{ docker_user }}"
       ansible.builtin.unarchive:
         src: "{{ docker_user_info.home }}/docker-{{ docker_release }}.tgz"
-        dest: "{{ docker_user_info.home }}/bin"
+        dest: "{{ docker_user_info.home }}/.local/bin"
         extra_opts:
           - --strip-components=1
         remote_src: true
       notify:
         - Restart rootless docker
 
-    - name: Extract docker-rootless-extras into Docker user bin directory
+    - name: Extract docker-rootless-extras into Docker user .local/bin directory
       become: true
       become_user: "{{ docker_user }}"
       ansible.builtin.unarchive:
         src: "{{ docker_user_info.home }}/docker-rootless-extras-{{ docker_release }}.tgz"
-        dest: "{{ docker_user_info.home }}/bin"
+        dest: "{{ docker_user_info.home }}/.local/bin"
         extra_opts:
           - --strip-components=1
         remote_src: true

--- a/tasks/docker_service.yml
+++ b/tasks/docker_service.yml
@@ -34,7 +34,7 @@
 
     - name: Set rootlesskit path as fact
       ansible.builtin.set_fact:
-        rootlesskit_path: "{{ docker_user_info.home }}/bin/rootlesskit"
+        rootlesskit_path: "{{ docker_user_info.home }}/.local/bin/rootlesskit"
 
     - name: Add rootlesskit AppArmor profile
       ansible.builtin.template:

--- a/tasks/docker_service_rootful.yml
+++ b/tasks/docker_service_rootful.yml
@@ -61,7 +61,7 @@
   become: true
   become_user: "{{ docker_user }}"
   environment:
-    PATH: "{{ docker_user_info.home }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     XDG_RUNTIME_DIR: /run/user/{{ docker_user_info.uid }}
   ansible.builtin.command:
     cmd: "dockerd-rootless-setuptool.sh install {{ '--skip-iptables' if ansible_facts.distribution == 'AlmaLinux' else omit }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     - docker_rootful
   environment:
     XDG_RUNTIME_DIR: /run/user/{{ docker_user_info.uid }}
-    PATH: "{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
+    PATH: "{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:{{ ansible_facts.env.PATH }}"
     DOCKER_HOST: unix:///run/user/{{ docker_user_info.uid }}/docker.sock
   when:
     - docker_rootful
@@ -66,7 +66,7 @@
     sudo_alias: >
       alias docker='sudo XDG_RUNTIME_DIR="/run/user/{{ docker_user_info.uid }}"
       DOCKER_HOST="unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
-      {{ docker_user_info.home }}/bin/docker'
+      {{ docker_user_info.home }}/.local/bin/docker'
   when:
     - docker_add_alias | bool
     - not docker_rootful

--- a/templates/docker_rootless.service.j2
+++ b/templates/docker_rootless.service.j2
@@ -7,13 +7,13 @@ Documentation=https://docs.docker.com/engine/security/rootless/
 
 [Service]
 Environment="DOCKER_HOST=unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
-Environment="PATH={{ docker_user_info.home }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="PATH={{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Environment="XDG_RUNTIME_DIR=/run/user/{{ docker_user_info.uid }}"
 {% if not docker_rootful %}
 {% if ansible_facts.distribution == "Debian" and ansible_facts.kernel >= "4.18" and ansible_facts.kernel <= "5.11" %}
-ExecStart={{ docker_user_info.home }}/bin/dockerd-rootless.sh -s fuse-overlayfs
+ExecStart={{ docker_user_info.home }}/.local/bin/dockerd-rootless.sh -s fuse-overlayfs
 {% else %}
-ExecStart={{ docker_user_info.home }}/bin/dockerd-rootless.sh {{ '--iptables=false' if ansible_facts.distribution == 'AlmaLinux' else '--iptables=true' }}
+ExecStart={{ docker_user_info.home }}/.local/bin/dockerd-rootless.sh {{ '--iptables=false' if ansible_facts.distribution == 'AlmaLinux' else '--iptables=true' }}
 {% endif %}
 {% endif %}
 {% if docker_rootful %}

--- a/templates/docker_rootless.sh.j2
+++ b/templates/docker_rootless.sh.j2
@@ -7,7 +7,7 @@
 # Ensure the following environment variables are set when managing
 # the docker service:
 #  XDG_RUNTIME_DIR="/run/user/{{ docker_user_info.uid }}"
-#  PATH="{{ docker_user_info.home }}/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+#  PATH="{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 #  DOCKER_HOST="unix:///run/user/{{ docker_user_info.uid }}/docker.sock"
 #
 # See https://docs.docker.com/engine/security/rootless/ for more information.
@@ -19,5 +19,5 @@
 
 sudo XDG_RUNTIME_DIR="/run/user/$(id -u {{ docker_user }})" \
   DOCKER_HOST="unix:///run/user/{{ docker_user_info.uid }}/docker.sock" \
-  PATH="{{ docker_user_info.home }}/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  PATH="{{ docker_user_info.home }}/.local/bin:{{ docker_user_info.home }}/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
     -i -u {{ docker_user }} docker "$@"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker and rootless Docker binaries are now installed in `~/.local/bin`.
  * Existing binaries in `~/bin` are automatically migrated on the first updated run by default.
  * Docker Compose and related tools now use the new binary location.
* **Bug Fixes**
  * Updated environment and service configuration ensures `~/.local/bin` takes precedence in `PATH`.
* **Documentation**
  * Added configuration guidance and updated container examples to reflect the new binary location and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->